### PR TITLE
Supporting updating labels on a Story

### DIFF
--- a/lib/pivotal/pivotal-api.rb
+++ b/lib/pivotal/pivotal-api.rb
@@ -59,6 +59,24 @@ module PivotalAPI
 
   class Story < Base
     self.site += 'projects/:project_id/'
+    schema do
+      attribute 'id', :integer
+      attribute 'project_id', :integer
+      attribute 'story_type', :string
+      attribute 'url', :string
+      attribute 'estimate', :integer
+      attribute 'current_state', :string
+      attribute 'description', :string
+      attribute 'name', :string
+      attribute 'requested_by', :string
+      attribute 'owned_by', :string
+      attribute 'labels', :string
+
+      # Use string for unsupported types per ActiveResource documentation
+      attribute 'created_at', :string
+      attribute 'updated_at', :string
+      attribute 'notes', :string
+    end
   end
 
   class Note < Base

--- a/lib/provider/ticket.rb
+++ b/lib/provider/ticket.rb
@@ -12,6 +12,7 @@ module TaskMapper::Provider
     # * assignee
     # * requestor
     # * project_id (prefix_options[:project_id])
+    # * labels
     class Ticket < TaskMapper::Provider::Base::Ticket
       @@allowed_states = ['new', 'open', 'resolved', 'hold', 'invalid']
 
@@ -97,9 +98,9 @@ module TaskMapper::Provider
         end
 
         def create(options)
-          super translate options, {:title => :name, 
+          super translate options, {:title => :name,
                                     :requestor => :requested_by,
-                                    :status => :current_state, 
+                                    :status => :current_state,
                                     :estimate => :priority,
                                     :assignee => :owned_by}
         end

--- a/spec/tickets_spec.rb
+++ b/spec/tickets_spec.rb
@@ -67,6 +67,13 @@ describe "TaskMapper::Provider::Pivotal::Ticket" do
     @ticket.save.should == true
   end
 
+  it "should be able to update a ticket to add a label and save the ticket" do
+    @ticket = @project.ticket(@ticket_id)
+    @ticket.labels = 'sample label'
+    @ticket.labels.should == 'sample label'
+    @ticket.save.should == true
+  end
+
   it "should be able to create a ticket" do
     @ticket = @project.ticket!(:title => 'Ticket #12', :description => 'Body')
     @ticket.should be_an_instance_of(@klass)
@@ -97,7 +104,7 @@ describe "TaskMapper::Provider::Pivotal::Ticket" do
     @ticket.save.should be_true
   end
 
-  it "should have all contract fields for tickets" do 
+  it "should have all contract fields for tickets" do
     @ticket = @project.ticket(@ticket_id)
     @ticket.title.should_not be_nil
     @ticket.description.should_not be_nil


### PR DESCRIPTION
Stories returned by the Pivotal API don't always include all fields (like labels) so when ActiveResource builds a list of known_attributes, they are not included and therefor can't be updated.

Explicitly setting the schema of fields supported by the PivotalAPI::Story class lets update fields that are supported by the API but not included in the fetched instance.

(Sorry about the extra edits for trailing whitespace)
